### PR TITLE
MagicColorSwap — tiny in-browser palette transformer

### DIFF
--- a/MagicColorSwap/app.js
+++ b/MagicColorSwap/app.js
@@ -1,0 +1,39 @@
+const palettes = {
+  moonlit: {bg:'#0b1020', fg:'#e6eef8', muted:'#93a6c4', accent:'#8b5cf6'},
+  aurora: {bg:'#071232', fg:'#eafff9', muted:'#86e3ce', accent:'#7b61ff'},
+  sunrise: {bg:'#fff7eb', fg:'#3a2b20', muted:'#b78a6f', accent:'#ff8a65'}
+};
+// Contributors add palettes here
+
+const sel = document.getElementById('palette');
+Object.keys(palettes).forEach(k=>{
+  const o = document.createElement('option'); o.value=k; o.textContent = k;
+  sel.appendChild(o);
+});
+sel.addEventListener('change', e => applyPalette(e.target.value));
+document.getElementById('export').addEventListener('click', ()=> {
+  const key = sel.value;
+  const css = generateCss(palettes[key]);
+  const out = document.getElementById('cssout');
+  out.hidden = false; out.textContent = css;
+});
+
+function applyPalette(key){
+  const p = palettes[key];
+  if(!p) return;
+  Object.entries(p).forEach(([k,v]) => {
+    document.documentElement.style.setProperty(`--${k}`, v);
+  });
+}
+
+function generateCss(p){
+  return `:root {
+  --bg: ${p.bg};
+  --fg: ${p.fg};
+  --muted: ${p.muted};
+  --accent: ${p.accent};
+}`;
+}
+
+// initial
+applyPalette('moonlit');

--- a/MagicColorSwap/index.html
+++ b/MagicColorSwap/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>MagicColorSwap</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>MagicColorSwap</h1>
+    <p>Choose a palette — watch the page transform. Add a palette as a PR!</p>
+    <select id="palette"></select>
+    <button id="export">Export CSS</button>
+    <section id="preview" class="card">
+      <h2>Preview Title</h2>
+      <p>Some enchanted paragraph to show contrast and spacing.</p>
+      <button class="cta">Action</button>
+    </section>
+    <pre id="cssout" hidden></pre>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/MagicColorSwap/readme.md
+++ b/MagicColorSwap/readme.md
@@ -1,0 +1,3 @@
+MagicColorSwap — tiny palette switcher.
+
+Contribute: add one palette entry to `palettes` in `app.js` (name + 4 hex colors).

--- a/MagicColorSwap/style.css
+++ b/MagicColorSwap/style.css
@@ -1,0 +1,12 @@
+:root{
+  --bg: #0b1020;
+  --fg: #e6eef8;
+  --muted: #93a6c4;
+  --accent: #8b5cf6;
+}
+*{box-sizing:border-box;font-family:Inter, Roboto, sans-serif}
+body{margin:0;background:var(--bg);color:var(--fg);padding:24px;min-height:100vh}
+main{max-width:720px;margin:0 auto}
+.card{background:linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.01));padding:20px;border-radius:12px;box-shadow:0 6px 30px rgba(2,6,23,0.6)}
+.cta{background:var(--accent);border:none;color:var(--bg);padding:8px 12px;border-radius:8px;cursor:pointer}
+pre{white-space:pre-wrap;padding:12px;margin-top:12px;background:#011;}


### PR DESCRIPTION
Add one new palette, or a “download CSS” improvement. Good for front-end contributors.